### PR TITLE
Fabric 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-+'
+	id 'fabric-loom' version '1.2-SNAPSHOT'
 	id "com.modrinth.minotaur" version "2.+"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 }
@@ -20,10 +20,10 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 ext.Versions = new Properties()
-Versions.load(file("Versionfiles/mcversion-1.19.3.properties").newReader())
+Versions.load(file("Versionfiles/mcversion-1.20.1.properties").newReader())
 
 archivesBaseName = "easiervillagertrading"
-ext.projectVersion = "1.5.4"
+ext.projectVersion = "1.5.5"
 
 version = "${Versions['minecraft_version']}-fabric${Versions['fabric_versiononly']}-${project.projectVersion}"
 
@@ -53,7 +53,7 @@ dependencies {
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = 'sources'
+	archiveClassifier = 'sources'
 	from sourceSets.main.allSource
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/de/guntram/mcmod/easiervillagertrading/BetterGuiMerchant.java
+++ b/src/main/java/de/guntram/mcmod/easiervillagertrading/BetterGuiMerchant.java
@@ -76,7 +76,7 @@ public class BetterGuiMerchant extends MerchantScreen implements AutoTrade {
             ItemStack invstack=handler.getSlot(i).getStack();
             if (invstack==null)
                 continue;
-            if (areItemStacksMergable(stack, invstack)) {
+            if (ItemStack.canCombine(stack, invstack)) {
                 //System.out.println("taking "+invstack.getCount()+" items from slot # "+i);
                 remaining-=invstack.getCount();
             }
@@ -94,7 +94,7 @@ public class BetterGuiMerchant extends MerchantScreen implements AutoTrade {
                 //System.out.println("can put result into empty slot "+i);
                 return true;
             }
-            if (areItemStacksMergable(stack, invstack)
+            if (ItemStack.canCombine(stack, invstack)
             &&  stack.getMaxCount() >= stack.getCount() + invstack.getCount()) {
                 //System.out.println("Can merge "+(invstack.getMaxStackSize()-invstack.getCount())+" items with slot "+i);
                 remaining-=(invstack.getMaxCount()-invstack.getCount());
@@ -142,7 +142,7 @@ public class BetterGuiMerchant extends MerchantScreen implements AutoTrade {
             if (invstack==null)
                 continue;
             boolean needPutBack=false;
-            if (areItemStacksMergable(stack, invstack)) {
+            if (ItemStack.canCombine(stack, invstack)) {
                 if (stack.getCount()+invstack.getCount() > stack.getMaxCount())
                     needPutBack=true;
                 remaining-=invstack.getCount();
@@ -161,16 +161,6 @@ public class BetterGuiMerchant extends MerchantScreen implements AutoTrade {
         return -1;
     }
     
-    private boolean areItemStacksMergable(ItemStack a, ItemStack b) {
-        if (a==null || b==null)
-            return false;
-        if (a.getItem() == b.getItem()
-        &&  (!a.isDamageable() || a.getDamage()==b.getDamage())
-        &&   ItemStack.areNbtEqual(a, b))
-            return true;
-        return false;
-    }
-    
     private void getslot(int slot, ItemStack stack, int... forbidden) {
         int remaining=stack.getCount();
         slotClick(slot);
@@ -179,7 +169,7 @@ public class BetterGuiMerchant extends MerchantScreen implements AutoTrade {
             if (invstack==null || invstack.isEmpty()) {
                 continue;
             }
-            if (areItemStacksMergable(stack, invstack)
+            if (ItemStack.canCombine(stack, invstack)
                 && invstack.getCount() < invstack.getMaxCount()
             ) {
                 // System.out.println("Can merge "+(invstack.getMaxStackSize()-invstack.getCount())+" items with slot "+i);


### PR DESCRIPTION
Updating the mod to 1.20.1 since it was broken in 1.20

Creating a PR for merge to 1.19 because no 1.20.1 branch exists. If you create one I can create a PR for that instead of 1.19

Changes:
In BetterGuiMerchant.java, Replaced method areItemStacksMergeable to ItemStack.canCombine since ItemStack.isNBTEqual doesn't exist anymore in 1.20. canCombine does the same job as areItemStacksMergeable

Updated gradle settings to include latest versions and changed some deprecated stuff.

Note: -
Settings are still broken because gbFabricTools needs a rewrite for 1.20. DrawableHelper was replaced by DrawContext. A lot of overrides don't work since the parents don't have the methods anymore. 

https://fabricmc.net/2023/05/25/120.html

Also created a separate PR for version files [here](https://github.com/gbl/Versionfiles/pull/8)